### PR TITLE
Delete expired Let's Encrypt certificate.

### DIFF
--- a/.github/kokoro/steps/hostsetup.sh
+++ b/.github/kokoro/steps/hostsetup.sh
@@ -19,6 +19,29 @@ echo "----------------------------------------"
 
 echo
 echo "========================================"
+echo "Update the CA certificates"
+echo "----------------------------------------"
+sudo apt-get install -y ca-certificates
+echo "----------------------------------------"
+sudo update-ca-certificates
+echo "----------------------------------------"
+
+echo
+echo "========================================"
+echo "Remove the expire letsencrypt.org cert "
+echo "----------------------------------------"
+wget https://helloworld.letsencrypt.org/ || true
+echo "----------------------------------------"
+sudo rm /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt
+echo "----------------------------------------"
+sudo update-ca-certificates
+echo "----------------------------------------"
+wget https://helloworld.letsencrypt.org/ || true
+echo "----------------------------------------"
+
+
+echo
+echo "========================================"
 echo "Host adding PPAs"
 echo "----------------------------------------"
 wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | sudo apt-key add -


### PR DESCRIPTION
The old `/usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt` Let's Encrypt certificate that has expired.

The "best" solution seems to be to delete the certificate. This is fine because the new non-expired
`/usr/share/ca-certificates/mozilla/ISRG_Root_X1.crt` certificate is still available.

See the post at https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/ for more explanation.